### PR TITLE
Make GitHub recognize .sol files as Solidity for syntax highlighting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sol linguist-language=Solidity


### PR DESCRIPTION
Example: https://github.com/DomKM/memefactory/blob/master/resources/public/contracts/src/Meme.sol

Solution sourced from: https://medium.com/@danielque/psa-how-to-fix-githubs-syntax-highlighting-for-solidity-4e9867c540b6