### PR TITLE
Moving the build environment to an env variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,10 +134,22 @@ lein test-dev
 
 Start UI advanced build:
 ```bash
-lein cljsbuild once "ui"
+MEMEFACTORY_ENV=dev lein cljsbuild once "ui"
 docker-compose up --build
 # go to http://localhost:3001/
 ```
+
+### QA and Production
+For qa and production builds all you need to do is set
+`MEMEFACTORY_ENV` appropriately. For example:
+```bash
+MEMEFACTORY_ENV=qa lein cljsbuild once "ui"
+```
+or
+```bash
+MEMEFACTORY_ENV=prod lein cljsbuild once "ui"
+```
+will build for the appropriate environment.
 
 ### Dank Faucet
 Naviagting to `/#/get-dank/index` allows you to verify your phone

--- a/project.clj
+++ b/project.clj
@@ -173,8 +173,7 @@
                                    :source-map-timestamp true
                                    :preloads [print.foo.preloads.devtools
                                               re-frisk.preload]
-                                   :closure-defines {"goog.DEBUG" true
-                                                     memefactory.ui.core.environment "dev"}
+                                   :closure-defines {"goog.DEBUG" true}
                                    :external-config {:devtools/config {:features-to-install :all}}}}
                        {:id "server"
                         :source-paths ["src"]
@@ -193,8 +192,7 @@
                                    :optimizations :advanced
                                    :pretty-print true
                                    :pseudo-names true
-                                   :closure-defines {"goog.DEBUG" true
-                                                     memefactory.ui.core.environment "prod"}}}
+                                   :closure-defines {"goog.DEBUG" true}}}
                        {:id "server-tests"
                         :source-paths ["src/memefactory/server" "src/memefactory/shared" "test/memefactory"]
                         :figwheel {:on-jsload "memefactory.tests.runner/on-jsload"}

--- a/src/memefactory/ui/config.cljs
+++ b/src/memefactory/ui/config.cljs
@@ -1,0 +1,37 @@
+(ns memefactory.ui.config
+  (:require [memefactory.shared.graphql-schema :refer [graphql-schema]])
+  (:require-macros [memefactory.ui.utils :refer [get-environment]]))
+
+(def development-config
+  {:logging {:level :debug
+             :console? true}
+   :time-source "blockchain"
+   :web3 {:url "http://localhost:8549"}
+   :graphql {:schema graphql-schema
+             :url "http://localhost:6300/graphql"}
+   :ipfs {:host "http://127.0.0.1:5001" :endpoint "/api/v0"}})
+
+(def qa-config
+  {:logging {:level :warn
+             :sentry {:dsn "https://4bb89c9cdae14444819ff0ac3bcba253@sentry.io/1306960"}}
+   :time-source "js-date"
+   :web3 {:url "http://qa.district0x.io:8545"}
+   :graphql {:schema graphql-schema
+             :url "http://qa.district0x.io:6300/graphql"}
+   :ipfs {:host "http://qa.district0x.io:5001" :endpoint "/api/v0"}})
+
+(def production-config
+  {:logging {:level :warn
+             :sentry {:dsn "https://4bb89c9cdae14444819ff0ac3bcba253@sentry.io/1306960"}}
+   :time-source "js-date"
+   :web3 {:url "http://memefactory.io:8545"}
+   :graphql {:schema graphql-schema
+             :url "http://memefactory.io:6300/graphql"}
+   :ipfs {:host "http://memefactory.io:5001" :endpoint "/api/v0"}})
+
+(def config
+  (condp = (get-environment)
+    "prod" production-config
+    "qa"   qa-config
+    "dev"  development-config
+    production-config))

--- a/src/memefactory/ui/utils.clj
+++ b/src/memefactory/ui/utils.clj
@@ -1,0 +1,9 @@
+(ns memefactory.ui.utils)
+
+(defmacro get-environment []
+  (let [env (or (System/getenv "MEMEFACTORY_ENV") "prod")]
+    ;; Write to stderr instead of stdout because the cljs compiler
+    ;; writes stdout to the raw JS file.
+    (binding [*out* *err*]
+      (println "Building with environment:" env))
+    env))


### PR DESCRIPTION
We needed this for the dank faucet, it requires the graphql endpoint
so we had to move the config out of core to avoid circular dependencies.