### PR TITLE
Add blacklist implementation for images

### DIFF
--- a/src/memefactory/server/core.cljs
+++ b/src/memefactory/server/core.cljs
@@ -52,7 +52,9 @@
                                                          (mount/stop #'memefactory.server.syncer/syncer
                                                                      #'memefactory.server.emailer/emailer))}
                             :ui {:public-key "2564e15aaf9593acfdc633bd08f1fc5c089aa43972dd7e8a36d67825cd0154602da47d02f30e1f74e7e72c81ba5f0b3dd20d4d4f0cc6652a2e719a0e9d4c7f10943"}
-                            :twilio-api-key "PUT_THE_REAL_KEY_HERE"}}})
+                            :twilio-api-key "PUT_THE_REAL_KEY_HERE" ;; TODO move this to config outside sources
+                            :blacklist-file "blacklist.edn" ;; TODO move this to config outside sources
+                            }}})
       (mount/start))
   (log/warn "System started" {:config @config} ::main))
 

--- a/src/memefactory/server/db.cljs
+++ b/src/memefactory/server/db.cljs
@@ -363,3 +363,8 @@
            :join [[:meme-tokens :mt] [:= :mt.meme-token/token-id :ma.meme-auction/token-id]
                   [:memes :m] [:= :mt.reg-entry/address :m.reg-entry/address]]
            :where [:= :ma.meme-auction/address auction-address]}))
+
+(defn patch-forbidden-reg-entry-image! [address]
+  (db/run! {:update :memes
+            :set {:meme/image-hash "forbidden-image-hash"}
+            :where [:= :reg-entry/address address]}))

--- a/src/memefactory/server/dev.cljs
+++ b/src/memefactory/server/dev.cljs
@@ -122,7 +122,10 @@
                                               :print-gas-usage? true}
                             :ranks-cache {:ttl (t/in-millis (t/minutes 60))}
                             :ui {:public-key "2564e15aaf9593acfdc633bd08f1fc5c089aa43972dd7e8a36d67825cd0154602da47d02f30e1f74e7e72c81ba5f0b3dd20d4d4f0cc6652a2e719a0e9d4c7f10943"}
-                            :twilio-api-key "PUT_THE_REAL_KEY_HERE"}}})
+                            :twilio-api-key "PUT_THE_REAL_KEY_HERE" ;; TODO move this to config outside sources
+                            :blacklist-file "blacklist.edn"
+                            :blacklist-token "123" ;; TODO move this to config outside sources
+                            }}})
       (mount/except [#'memefactory.server.emailer/emailer])
       (mount/start)
       pprint/pprint))

--- a/src/memefactory/server/graphql_resolvers.cljs
+++ b/src/memefactory/server/graphql_resolvers.cljs
@@ -11,6 +11,7 @@
             [district.graphql-utils :as graphql-utils]
             [district.server.config :refer [config]]
             [district.server.db :as db]
+            [memefactory.server.db :as mf-db]
             [district.server.smart-contracts :as smart-contracts]
             [district.server.web3 :as web3]
             [honeysql.core :as sql]
@@ -1012,6 +1013,22 @@
                           {:success false
                            :payload stderr}))))))))))
 
+(defn blacklist-reg-entry-resolver [_ {:keys [address token] :as args}]
+
+  (let [{:keys [blacklist-token blacklist-file]} @config]
+    (if (= token blacklist-token)
+
+      (do
+        ;; update the blacklist file
+        (-> (utils/load-edn-file blacklist-file)
+            (update :blacklisted-image-addresses conj address)
+            (utils/save-to-edn-file blacklist-file))
+        ;;  patch on db
+        (mf-db/patch-forbidden-reg-entry-image! address)
+        (log/info (str "Blacklisted " address " image.") ::blacklist-reg-entry-resolver))
+
+      (log/warn (str "Tried to blacklist reg entry " address " with wrong token " token) ::blacklist-reg-entry-resolver))))
+
 (def resolvers-map
   {:Query {:meme meme-query-resolver
            :search-memes search-memes-query-resolver
@@ -1028,7 +1045,8 @@
            :overall-stats overall-stats-resolver
            :config config-query-resolver}
    :Mutation {:send-verification-code send-verification-code-resolver
-              :encrypt-verification-payload encrypt-verification-payload-resolver}
+              :encrypt-verification-payload encrypt-verification-payload-resolver
+              :blacklist-reg-entry blacklist-reg-entry-resolver}
    :Vote {:vote/option vote->option-resolver
           :vote/reward vote->reward-resolver}
    :Meme {:reg-entry/status reg-entry->status-resolver

--- a/src/memefactory/shared/graphql_schema.cljs
+++ b/src/memefactory/shared/graphql_schema.cljs
@@ -81,12 +81,14 @@
   type Mutation {
     sendVerificationCode(countryCode: String!,
                          phoneNumber: String!
-  ): PhoneVerificationResponse
+    ): PhoneVerificationResponse
 
     encryptVerificationPayload(countryCode: String,
                                phoneNumber: String,
                                verificationCode: String
     ): EncryptedVerificationPayload
+
+    blacklistRegEntry(address: ID!, token: String!): Boolean
   }
 
   enum OrderDir {


### PR DESCRIPTION
dd graphql mutation to blacklist a reg-entry image with reg-entry address and auth token as parameters
(token should be added in config, next to our private key, somewhere it doesn't end up on github)

When you blacklist a image it does two things :
- patches the image hash in meme table with a default image hash
- adds it to a blacklisted.edn file

Modify syncer so after replaying all past events, reads the blacklisted.edn and apply the patches again, then start.