### PR TITLE
Fixed 'Vote Reward' button labelling, along with several others

### DIFF
--- a/src/memefactory/styles/component/buttons.clj
+++ b/src/memefactory/styles/component/buttons.clj
@@ -15,7 +15,9 @@
   [:&
    (font :bungee)
    {:border-radius (em 2)
-    :display "block"
+    :display :flex
+    :align-items :center
+    :justify-content :center
     :height (or height (em 2))
     :width (or width (em 8))
     :border-style "none"
@@ -24,7 +26,18 @@
     :background-color (c/color background-color)
     :white-space :nowrap}
    [:&:disabled
-    {:opacity 0.3}]])
+    {:opacity 0.3}]
+
+   [:.label
+    {:display :flex
+     :height (or height (em 2))
+     :width (or width (em 8))
+     :align-items :center
+     :justify-content :center}
+
+    [:img
+     {:height (or height (em 1.8))
+      :width (or height (em 1.8))}]]])
 
 
 (defn get-dank-button []

--- a/src/memefactory/ui/components/buttons.cljs
+++ b/src/memefactory/ui/components/buttons.cljs
@@ -27,7 +27,10 @@
          (if not-revealed?
            [pending-button {:pending? @claim-vote-amount-tx-pending?
                             :disabled (or @claim-vote-amount-tx-pending? @claim-vote-amount-tx-success?)
-                            :pending-text "Collecting ..."
+                            :pending-text [:div.label
+                                           [:span "Reclaiming"]
+                                           [:img {:src "/assets/icons/dank-logo.svg"}]
+                                           [:span "..."]]
                             :class "collect-amount"
                             :on-click (fn []
                                         (dispatch [::registry-entry/claim-vote-amount (look {:send-tx/id vote-amount-tx-id
@@ -38,14 +41,17 @@
             (if @claim-vote-amount-tx-success?
               "Collected"
               [:div.label
-                 [:span "Reclaim"]
-                 [:img {:src "/assets/icons/dank-logo.svg"}]
-                 [:span "Votes"]])]
+               [:span "Reclaim"]
+               [:img {:src "/assets/icons/dank-logo.svg"}]
+               [:span "Votes"]])]
 
            (when vote-winning-vote-option
              [pending-button {:pending? @claim-vote-reward-tx-pending?
                               :disabled (or @claim-vote-reward-tx-pending? @claim-vote-reward-tx-success?)
-                              :pending-text "Collecting ..."
+                              :pending-text [:div.label
+                                             [:span "Claiming"]
+                                             [:img {:src "/assets/icons/dank-logo.svg"}]
+                                             [:span "..."]]
                               :class "collect-reward"
                               :on-click (fn []
                                           (dispatch [::registry-entry/claim-vote-reward (look {:send-tx/id vote-reward-tx-id
@@ -64,7 +70,10 @@
          [pending-button {:pending? @claim-challenge-reward-tx-pending?
                           :disabled (or (not (pos? (:challenge/reward-amount all-rewards)))
                                         @claim-challenge-reward-tx-pending? @claim-challenge-reward-tx-success?)
-                          :pending-text "Collecting ..."
+                          :pending-text [:div.label
+                                         [:span "Claiming"]
+                                         [:img {:src "/assets/icons/dank-logo.svg"}]
+                                         [:span "..."]]
                           :on-click (fn []
                                       (dispatch [::registry-entry/claim-challenge-reward {:send-tx/id ch-reward-tx-id
                                                                                           :active-account active-account

--- a/src/memefactory/ui/components/buttons.cljs
+++ b/src/memefactory/ui/components/buttons.cljs
@@ -37,7 +37,10 @@
 
             (if @claim-vote-amount-tx-success?
               "Collected"
-              "Reclaim votes")]
+              [:div.label
+                 [:span "Reclaim"]
+                 [:img {:src "/assets/icons/dank-logo.svg"}]
+                 [:span "Votes"]])]
 
            (when vote-winning-vote-option
              [pending-button {:pending? @claim-vote-reward-tx-pending?
@@ -51,7 +54,10 @@
                                                                                                :meme/title (:meme/title meme)})]))}
               (if @claim-vote-reward-tx-success?
                 "Collected"
-                "Vote reward")])))
+                [:div.label
+                 [:span "Claim"]
+                 [:img {:src "/assets/icons/dank-logo.svg"}]
+                 [:span "Reward"]])])))
 
        (when (and (= (:user/address challenger) active-account)
                   (> votes-against votes-for))
@@ -66,4 +72,8 @@
                                                                                           :meme/title (:meme/title meme)}]))}
           (if @claim-challenge-reward-tx-success?
             "Collected"
-            "Challenge Reward")])])))
+            [:div.label
+             [:span "Claim"]
+             [:img {:src "/assets/icons/dank-logo.svg"}]
+             [:span "Reward"]])])])))
+            

--- a/src/memefactory/ui/components/buttons.cljs
+++ b/src/memefactory/ui/components/buttons.cljs
@@ -39,7 +39,10 @@
                                                                                              :meme/title (:meme/title meme)})]))}
 
             (if @claim-vote-amount-tx-success?
-              "Collected"
+              [:div.label
+               [:span "Reclaimed"]
+               [:img {:src "/assets/icons/dank-logo.svg"}]]
+
               [:div.label
                [:span "Reclaim"]
                [:img {:src "/assets/icons/dank-logo.svg"}]
@@ -59,7 +62,10 @@
                                                                                                :reg-entry/address address
                                                                                                :meme/title (:meme/title meme)})]))}
               (if @claim-vote-reward-tx-success?
-                "Collected"
+                [:div.label
+                 [:span "Claimed"]
+                 [:img {:src "/assets/icons/dank-logo.svg"}]]
+
                 [:div.label
                  [:span "Claim"]
                  [:img {:src "/assets/icons/dank-logo.svg"}]
@@ -80,7 +86,10 @@
                                                                                           :reg-entry/address address
                                                                                           :meme/title (:meme/title meme)}]))}
           (if @claim-challenge-reward-tx-success?
-            "Collected"
+            [:div.label
+             [:span "Claimed"]
+             [:img {:src "/assets/icons/dank-logo.svg"}]]
+
             [:div.label
              [:span "Claim"]
              [:img {:src "/assets/icons/dank-logo.svg"}]


### PR DESCRIPTION
- 'Vote Reward' was changed to 'Claim <dank-logo> Reward'
- 'Challenge Reward' was changed to 'Claim <dank-logo> Reward'
- 'Reclaim Votes' was changed to 'Reclaim <dank-logo> Votes'
- fixes #194 

## Before
![dank before](https://i.imgur.com/nW19BSe.png)

## After
![dank after](https://i.imgur.com/bn5SlJD.png)
![reclaim after](https://i.imgur.com/4yKyKqu.png)