### PR TITLE
Pass the http-resp between events so we can extract the encrypted payload

### DIFF
--- a/src/memefactory/ui/get_dank/events.cljs
+++ b/src/memefactory/ui/get_dank/events.cljs
@@ -74,11 +74,11 @@
 
 (re-frame/reg-event-fx
  ::encrypt-payload-success
- (fn [{:keys [db]} [_ {:keys [country-code phone-number verification-code] :as data}]]
-   ()
+ (fn [{:keys [db]} [_ {:keys [country-code phone-number verification-code] :as data} http-resp]]
+   (log/info "Encryption success:" data)
    {:db (assoc db
           ::spinner true)
-    :dispatch [::verify-and-acquire-dank data]}))
+    :dispatch [::verify-and-acquire-dank data http-resp]}))
 
 (re-frame/reg-event-fx
  ::verify-and-acquire-dank


### PR DESCRIPTION
Minor fix for the Faucet front-end.