### PR TITLE
Fixes for iphone animation performance issues

### DIFF
--- a/src/memefactory/styles/component/compact_tile.clj
+++ b/src/memefactory/styles/component/compact_tile.clj
@@ -39,7 +39,8 @@
 
 
 (def default-animation-style
-  {:animation-duration animation-speed
+  {:-webkit-animation-duration animation-speed
+   :animation-duration animation-speed
    :animation-fill-mode :both
    :animation-timing-function animation-timing
    :-webkit-transform-style :preserve-3d
@@ -106,12 +107,15 @@
   ;; General Fade In Animation
   [:.initial-fade-in-delay
    {:animation-name :initial-fade-in
+    :-webkit-animation-delay "0.35s"
     :animation-delay "0.35s"
+    :-webkit-animation-duration "0.50s"
     :animation-duration "0.50s"
     :animation-fill-mode :both}]
 
   [:.initial-fade-in
    {:animation-name :initial-fade-in
+    :-webkit-animation-duration "0.50s"
     :animation-duration "0.50s"
     :animation-fill-mode :both}]
 
@@ -131,6 +135,11 @@
     :grid-template-columns (px card-width)
     :width (px card-width)
     :height (px card-height)}
+   (for-media-max
+    :tablet
+    [:& {:perspective :none
+         :-webkit-transform-style :flat
+         :transform-style :flat}])
 
    ;; Front of flippable card styling
    [:.flippable-tile-front


### PR DESCRIPTION
- fixes #301 
- added additional vendor prefixes for webkit for older browsers
- When viewing on a mobile, removed certain 3d animation effects (perspective, transform styling) which might be causing issues