### PR TITLE
Feature: Configurable smart-contracts based on ENV var

### DIFF
--- a/migrations/utils.js
+++ b/migrations/utils.js
@@ -41,7 +41,7 @@ const utils = {
   },
 
   smartContractsTemplate: (map) => {
-    return `(ns memefactory.shared.smart-contracts)
+    return `(ns memefactory.shared.smart-contracts-dev)
 
   (def smart-contracts
     ${map})

--- a/src/memefactory/server/core.cljs
+++ b/src/memefactory/server/core.cljs
@@ -22,11 +22,21 @@
    [memefactory.server.sigterm]
    [memefactory.server.syncer]
    [memefactory.shared.graphql-schema :refer [graphql-schema]]
-   [memefactory.shared.smart-contracts]
+   [memefactory.shared.smart-contracts-dev :as smart-contracts-dev]
+   [memefactory.shared.smart-contracts-prod :as smart-contracts-prod]
+   [memefactory.shared.smart-contracts-qa :as smart-contracts-qa]
    [mount.core :as mount]
-   [taoensso.timbre :as log]))
+   [taoensso.timbre :as log])
+  (:require-macros [memefactory.shared.utils :refer [get-environment]]))
 
 (nodejs/enable-util-print!)
+
+(def contracts-var
+  (condp = (get-environment)
+    "prod" #'smart-contracts-prod/smart-contracts
+    "qa" #'smart-contracts-qa/smart-contracts
+    "qa-dev" #'smart-contracts-qa/smart-contracts
+    "dev" #'smart-contracts-dev/smart-contracts))
 
 (defn -main [& _]
   (-> (mount/with-args
@@ -43,7 +53,7 @@
                                       :graphiql false}
                             :web3 {:url "localhost:8545"}
                             :ipfs {:host "http://127.0.0.1:5001" :endpoint "/api/v0" :gateway "http://127.0.0.1:8080/ipfs"}
-                            :smart-contracts {:contracts-var #'memefactory.shared.smart-contracts/smart-contracts}
+                            :smart-contracts {:contracts-var contracts-var}
                             :ranks-cache {:ttl (t/in-millis (t/minutes 60))}
                             :web3-watcher {:on-online (fn []
                                                         (log/warn "Ethereum node went online again" ::web3-watcher)

--- a/src/memefactory/shared/smart_contracts_dev.cljs
+++ b/src/memefactory/shared/smart_contracts_dev.cljs
@@ -1,0 +1,66 @@
+(ns memefactory.shared.smart-contracts-dev)
+
+(def smart-contracts
+  {:district-config
+   {:name "DistrictConfig"
+    :address "0x0000000000000000000000000000000000000000"}
+   :ds-guard
+   {:name "DSGuard"
+    :address "0x0000000000000000000000000000000000000000"}
+   :param-change-registry
+   {:name "ParamChangeRegistry"
+    :address "0x0000000000000000000000000000000000000000"}
+   :param-change-registry-db
+   {:name "EternalDb"
+    :address "0x0000000000000000000000000000000000000000"}
+   :meme-registry-db
+   {:name "EternalDb"
+    :address "0x0000000000000000000000000000000000000000"}
+   :param-change
+   {:name "ParamChange"
+    :address "0x0000000000000000000000000000000000000000"}
+   :minime-token-factory
+   {:name "MiniMeTokenFactory"
+    :address "0x0000000000000000000000000000000000000000"}
+   :meme-auction-factory
+   {:name "MemeAuctionFactory"
+    :address "0x0000000000000000000000000000000000000000"}
+   :meme-auction
+   {:name "MemeAuction"
+    :address "0x0000000000000000000000000000000000000000"}
+   :param-change-factory
+   {:name "ParamChangeFactory"
+    :address "0x0000000000000000000000000000000000000000"}
+   :param-change-registry-fwd
+   {:name "MutableForwarder"
+    :address "0x0000000000000000000000000000000000000000"
+    :forwards-to :param-change-registry}
+   :meme-factory
+   {:name "MemeFactory"
+    :address "0x0000000000000000000000000000000000000000"}
+   :meme-token
+   {:name "MemeToken"
+    :address "0x0000000000000000000000000000000000000000"}
+   :DANK
+   {:name "DankToken"
+    :address "0x0000000000000000000000000000000000000000"}
+   :meme-registry
+   {:name "Registry"
+    :address "0x0000000000000000000000000000000000000000"}
+   :meme
+   {:name "Meme"
+    :address "0x0000000000000000000000000000000000000000"}
+   :meme-registry-fwd
+   {:name "MutableForwarder"
+    :address "0x0000000000000000000000000000000000000000"
+    :forwards-to :meme-registry}
+   :meme-auction-factory-fwd
+   {:name "MutableForwarder"
+    :address "0x0000000000000000000000000000000000000000"
+    :forwards-to :meme-auction-factory}
+   :district0x-emails
+   {:name "District0xEmails"
+    :address "0x0000000000000000000000000000000000000000"}
+   :dank-faucet
+   {:name "DankFaucet"
+    :address "0x0000000000000000000000000000000000000000"}})

--- a/src/memefactory/shared/smart_contracts_prod.cljs
+++ b/src/memefactory/shared/smart_contracts_prod.cljs
@@ -1,0 +1,66 @@
+(ns memefactory.shared.smart-contracts-prod)
+
+(def smart-contracts
+  {:district-config
+   {:name "DistrictConfig"
+    :address "0x0000000000000000000000000000000000000000"}
+   :ds-guard
+   {:name "DSGuard"
+    :address "0x0000000000000000000000000000000000000000"}
+   :param-change-registry
+   {:name "ParamChangeRegistry"
+    :address "0x0000000000000000000000000000000000000000"}
+   :param-change-registry-db
+   {:name "EternalDb"
+    :address "0x0000000000000000000000000000000000000000"}
+   :meme-registry-db
+   {:name "EternalDb"
+    :address "0x0000000000000000000000000000000000000000"}
+   :param-change
+   {:name "ParamChange"
+    :address "0x0000000000000000000000000000000000000000"}
+   :minime-token-factory
+   {:name "MiniMeTokenFactory"
+    :address "0x0000000000000000000000000000000000000000"}
+   :meme-auction-factory
+   {:name "MemeAuctionFactory"
+    :address "0x0000000000000000000000000000000000000000"}
+   :meme-auction
+   {:name "MemeAuction"
+    :address "0x0000000000000000000000000000000000000000"}
+   :param-change-factory
+   {:name "ParamChangeFactory"
+    :address "0x0000000000000000000000000000000000000000"}
+   :param-change-registry-fwd
+   {:name "MutableForwarder"
+    :address "0x0000000000000000000000000000000000000000"
+    :forwards-to :param-change-registry}
+   :meme-factory
+   {:name "MemeFactory"
+    :address "0x0000000000000000000000000000000000000000"}
+   :meme-token
+   {:name "MemeToken"
+    :address "0x0000000000000000000000000000000000000000"}
+   :DANK
+   {:name "DankToken"
+    :address "0x0000000000000000000000000000000000000000"}
+   :meme-registry
+   {:name "Registry"
+    :address "0x0000000000000000000000000000000000000000"}
+   :meme
+   {:name "Meme"
+    :address "0x0000000000000000000000000000000000000000"}
+   :meme-registry-fwd
+   {:name "MutableForwarder"
+    :address "0x0000000000000000000000000000000000000000"
+    :forwards-to :meme-registry}
+   :meme-auction-factory-fwd
+   {:name "MutableForwarder"
+    :address "0x0000000000000000000000000000000000000000"
+    :forwards-to :meme-auction-factory}
+   :district0x-emails
+   {:name "District0xEmails"
+    :address "0x0000000000000000000000000000000000000000"}
+   :dank-faucet
+   {:name "DankFaucet"
+    :address "0x0000000000000000000000000000000000000000"}})

--- a/src/memefactory/shared/smart_contracts_qa.cljs
+++ b/src/memefactory/shared/smart_contracts_qa.cljs
@@ -1,4 +1,4 @@
-(ns memefactory.shared.smart-contracts)
+(ns memefactory.shared.smart-contracts-qa)
 
 (def smart-contracts
   {:district-config

--- a/src/memefactory/shared/utils.clj
+++ b/src/memefactory/shared/utils.clj
@@ -1,4 +1,4 @@
-(ns memefactory.ui.utils)
+(ns memefactory.shared.utils)
 
 (defmacro get-environment []
   (let [env (or (System/getenv "MEMEFACTORY_ENV") "dev")]

--- a/src/memefactory/ui/config.cljs
+++ b/src/memefactory/ui/config.cljs
@@ -5,16 +5,23 @@
    [district.ui.logging.events :as logging]
    [graphql-query.core :refer [graphql-query]]
    [memefactory.shared.graphql-schema :refer [graphql-schema]]
+   [memefactory.shared.smart-contracts-dev :as smart-contracts-dev]
+   [memefactory.shared.smart-contracts-prod :as smart-contracts-prod]
+   [memefactory.shared.smart-contracts-qa :as smart-contracts-qa]
    [mount.core :refer [defstate]]
    [re-frame.core :as re-frame]
    [taoensso.timbre :as log])
-  (:require-macros [memefactory.ui.utils :refer [get-environment]]))
+  (:require-macros [memefactory.shared.utils :refer [get-environment]]))
+
+(def skipped-contracts [:ds-guard :param-change-registry-db :meme-registry-db :minime-token-factory])
 
 (def development-config
   {:debug? true
    :logging {:level :debug
              :console? true}
    :time-source :js-date
+   :smart-contracts {:contracts (apply dissoc smart-contracts-dev/smart-contracts skipped-contracts)}
+   :web3-balances {:contracts (select-keys smart-contracts-dev/smart-contracts [:DANK])}
    :web3 {:url "http://localhost:8549"}
    :web3-tx-log {:disable-using-localstorage? true
                  :open-on-tx-hash? true
@@ -33,6 +40,8 @@
              :sentry {:dsn "https://4bb89c9cdae14444819ff0ac3bcba253@sentry.io/1306960"
                       :environment "QA"}}
    :time-source :js-date
+   :smart-contracts {:contracts (apply dissoc smart-contracts-qa/smart-contracts skipped-contracts)}
+   :web3-balances {:contracts (select-keys smart-contracts-qa/smart-contracts [:DANK])}
    :web3 {:url "http://qa.district0x.io:8545"}
    :web3-tx-log {:disable-using-localstorage? false
                  :open-on-tx-hash? true
@@ -52,6 +61,8 @@
              :sentry {:dsn "https://4bb89c9cdae14444819ff0ac3bcba253@sentry.io/1306960"
                       :environment "PRODUCTION"}}
    :time-source :js-date
+   :smart-contracts {:contracts (apply dissoc smart-contracts-prod/smart-contracts skipped-contracts)}
+   :web3-balances {:contracts (select-keys smart-contracts-prod/smart-contracts [:DANK])}
    :web3 {:url "http://memefactory.io:8545"}
    :web3-tx-log {:disable-using-localstorage? false
                  :open-on-tx-hash? true

--- a/src/memefactory/ui/core.cljs
+++ b/src/memefactory/ui/core.cljs
@@ -24,7 +24,6 @@
    [memefactory.shared.contract.registry-entry]
    [memefactory.shared.graphql-schema :refer [graphql-schema]]
    [memefactory.shared.routes :refer [routes]]
-   [memefactory.shared.smart-contracts :refer [smart-contracts]]
    [memefactory.ui.about.page]
    [memefactory.ui.config :as config]
    [memefactory.ui.config :refer [config-map]]
@@ -72,9 +71,7 @@
   (dev-setup)
   (let [full-config (cljs-utils/merge-in
                       config-map
-                      {:smart-contracts {:contracts (apply dissoc smart-contracts skipped-contracts)
-                                         :format :truffle-json}
-                       :web3-balances {:contracts (select-keys smart-contracts [:DANK])}
+                      {:smart-contracts {:format :truffle-json}
                        :web3-account-balances {:for-contracts [:ETH :DANK]}
                        :web3-tx-log {:open-on-tx-hash? true}
                        :reagent-render {:id "app"

--- a/test/memefactory/tests/smart_contracts/deployment_tests.cljs
+++ b/test/memefactory/tests/smart_contracts/deployment_tests.cljs
@@ -21,7 +21,7 @@
             [memefactory.server.contract.registry :as registry]
             [memefactory.server.contract.registry-entry :as registry-entry]
             [memefactory.server.macros :refer [promise->]]
-            [memefactory.shared.smart-contracts :refer [smart-contracts]]
+            [memefactory.shared.smart-contracts-dev :refer [smart-contracts]]
             [memefactory.tests.smart-contracts.utils :refer [now create-before-fixture after-fixture]]
             [print.foo :include-macros true]))
 

--- a/test/memefactory/tests/smart_contracts/utils.cljs
+++ b/test/memefactory/tests/smart_contracts/utils.cljs
@@ -6,7 +6,7 @@
    [cljs-web3.eth :as web3-eth]
    [cljs.test :refer-macros [deftest is testing run-tests use-fixtures async]]
    [district.server.web3 :refer [web3]]
-   [memefactory.shared.smart-contracts :refer [smart-contracts]]
+   [memefactory.shared.smart-contracts-dev :refer [smart-contracts]]
    [district.server.smart-contracts :refer [instance]]
    [mount.core :as mount]
    [cljs.core.async :as async :refer-macros [go]]))

--- a/truffle.js
+++ b/truffle.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = {
-  smart_contracts_path: __dirname + '/src/memefactory/shared/smart_contracts.cljs',
+  smart_contracts_path: __dirname + '/src/memefactory/shared/smart_contracts_dev.cljs',
   contracts_build_directory: __dirname + '/resources/public/contracts/build/',
   parameters : {
     memeRegistryDb : {challengePeriodDuration : 600, // seconds


### PR DESCRIPTION
I propose following solution to the problem of configurable smart-contract addresses as a better alternative to async loading of contracts in UI. We can just have 3 smart_contracts.cljs files and based on MEMEFACTORY_ENV it'll choose the right one during the compilation. 