### PR TITLE
EIP1102 Fixes for deprecated authorization

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -53,7 +53,7 @@
                  [district0x/district-ui-router "1.0.5"]
                  [district0x/district-ui-router-google-analytics "1.0.1"]
                  [district0x/district-ui-smart-contracts "1.0.6"]
-                 [district0x/district-ui-web3 "1.1.0-SNAPSHOT"]
+                 [district0x/district-ui-web3 "1.2.0"]
                  [district0x/district-ui-web3-account-balances "1.0.2"]
                  [district0x/district-ui-web3-accounts "1.0.5"]
                  [district0x/district-ui-web3-balances "1.0.2"]


### PR DESCRIPTION
Includes a version bump of district-ui-web3, with changes outlined in [this commit](https://github.com/district0x/district-ui-web3/commit/b59a07ad75c88f6035303c86c1301ac9333a11d8)