### PR TITLE
Transaction pop styling fix 438

### DIFF
--- a/src/memefactory/styles/component/account_balances.clj
+++ b/src/memefactory/styles/component/account_balances.clj
@@ -13,6 +13,9 @@
 (def bar-height 50) ;; px
 (def account-balance-width 270) ;; px
 
+;; Alternative width for when account balances component is placed in
+;; the app-bar
+(def account-balance-app-bar-width 320) ;; px
 
 (def account-section-style
   {:display :grid
@@ -23,6 +26,11 @@
    :width (px (/ account-balance-width 2))})
 
 
+(def account-section-app-bar-style
+  (assoc account-section-style
+         :width (px (/ account-balance-app-bar-width 2))))
+
+
 (defstyles core
   [:.accounts
    {:display :grid
@@ -31,9 +39,8 @@
        'tx-log       tx-log'"
     :height "100%"
     :width (px account-balance-width)
-    :margin-right (em 1.01)
-
     :background-color (color :ticker-background)}
+
    [:.dank-section
     (merge
      {:grid-area :dank-section
@@ -44,6 +51,7 @@
       :display :flex
       :justify-content :center}
      account-section-style)
+
     [:.dank-logo
      {:grid-area :logo
       :display :flex
@@ -59,6 +67,7 @@
       :display :flex
       :justify-content :center}
      account-section-style)
+    [:&.app-bar-width account-section-app-bar-style]
     [:.eth-logo
      {:grid-area :logo
       :display :flex
@@ -230,4 +239,10 @@
       :text-overflow :ellipsis}]
     [:.token-code
      {:white-space :nowrap
-      :color (color :ticker-token-color)}]]])
+      :color (color :ticker-token-color)}]]
+
+   [:&.app-bar-width
+    {:width (px account-balance-app-bar-width)}
+    [:.dank-section account-section-app-bar-style]
+    [:.eth-section account-section-app-bar-style]
+    [:.tx-log {:width (px account-balance-app-bar-width)}]]])

--- a/src/memefactory/styles/component/account_balances.clj
+++ b/src/memefactory/styles/component/account_balances.clj
@@ -31,6 +31,8 @@
        'tx-log       tx-log'"
     :height "100%"
     :width (px account-balance-width)
+    :margin-right (em 1.01)
+
     :background-color (color :ticker-background)}
    [:.dank-section
     (merge

--- a/src/memefactory/styles/component/account_balances.clj
+++ b/src/memefactory/styles/component/account_balances.clj
@@ -67,7 +67,7 @@
       :display :flex
       :justify-content :center}
      account-section-style)
-    [:&.app-bar-width account-section-app-bar-style]
+
     [:.eth-logo
      {:grid-area :logo
       :display :flex

--- a/src/memefactory/styles/component/app_bar.clj
+++ b/src/memefactory/styles/component/app_bar.clj
@@ -102,7 +102,7 @@
    [:.tracker-section
     {:cursor :pointer
      :transition "width 100ms cubic-bezier(0.23, 1, 0.32, 1) 0ms"
-     :width (px 270)
+     :width (px 320)
      :height "100%"
      :display :flex
      :align-items :center

--- a/src/memefactory/styles/pages/how_it_works.clj
+++ b/src/memefactory/styles/pages/how_it_works.clj
@@ -34,10 +34,10 @@
                :align-items :center
                :justify-content :space-evenly}
      [:.metamask-wallet
-      (for-media-max :tablet
+      #_(for-media-max :tablet
                      [:& {:display :none}])
       [:img {:width (px 130)}]]
      [:.coinbase-wallet
-      (for-media-min :tablet
+      #_(for-media-min :tablet
                      [:& {:display :none}])
       [:img {:width (px 130)}]]]]])

--- a/src/memefactory/ui/components/account_balances.cljs
+++ b/src/memefactory/ui/components/account_balances.cljs
@@ -8,10 +8,23 @@
    [re-frame.core :as re]))
 
 
-(defn account-balances [{:keys [with-tx-logs?]}]
+(defn account-balances
+  "Account Balances (with transactions) Component
+
+  # Optional Arguments
+
+  with-tx-logs? -- Determines whether to include the transactions log
+  drop-down [default: false]
+
+  app-bar-width? -- Determines whether to make the component slightly wider
+  for situations when it's in the app-bar [default: false]
+
+  "
+  [{:keys [with-tx-logs? app-bar-width?]}]
   (let [tx-log-open? (re/subscribe [::tx-log-subs/open?])]
     (fn []
       [:div.accounts
+       {:class (when app-bar-width? "app-bar-width")}
        [:div.dank-section
         {:on-click (when with-tx-logs? #(re/dispatch [::tx-log-events/set-open (not @tx-log-open?)]))}
         [:div.dank-logo

--- a/src/memefactory/ui/components/app_layout.cljs
+++ b/src/memefactory/ui/components/app_layout.cljs
@@ -113,7 +113,7 @@
                        (dispatch [:district.ui.router.events/navigate :route/how-it-works])
                        (dispatch [:district0x.transaction-log/set-open (not @open?)])))}
         (when (seq @accounts)
-          [account-balances {:with-tx-logs? true}])]])))
+          [account-balances {:with-tx-logs? true :app-bar-width? true}])]])))
 
 
 (defn district0x-banner []


### PR DESCRIPTION
- Fixes #438 
  - Changes account balance width to be as wide as namebazaar, which shows appropriate margins for transaction logs
- Fixes #446 
  - Removes media queries that are unintentionally removing coinbase logo
