### PR TITLE
Check the contract instead of local storage for the email

### DIFF
--- a/src/memefactory/ui/core.cljs
+++ b/src/memefactory/ui/core.cljs
@@ -15,6 +15,7 @@
    [district.ui.smart-contracts]
    [district.ui.web3-account-balances]
    [district.ui.web3-accounts]
+   [district.ui.web3-accounts.events]
    [district.ui.web3-balances]
    [district.ui.web3-tx-id]
    [district.ui.web3-tx-log]
@@ -45,6 +46,7 @@
    [memefactory.ui.meme-detail.page]
    [memefactory.ui.memefolio.page]
    [memefactory.ui.my-settings.page]
+   [memefactory.ui.my-settings.events]
    [memefactory.ui.subs]
    [mount.core :as mount]
    [print.foo :refer [look] :include-macros true]
@@ -68,21 +70,32 @@
                :votes (:votes store)
                :memefactory.ui.get-dank.page/stage 1)}))
 
+;; This is fired whenever the system has a new account.
+;; Could be a user chainging its account on metamask or
+;; when the account is loaded the first time.
+;; When we are sure we have an account we can load user emails
+;; settings.
+(re-frame/reg-event-fx
+ :district.ui.web3-accounts.events/active-account-changed
+ (fn [_ [_ {:keys [new]}]]
+   (when new
+     {:dispatch [:memefactory.ui.my-settings.events/load-email-settings
+                 {:address new}]})))
 
 (defn ^:export init []
   (dev-setup)
   (let [full-config (cljs-utils/merge-in
-                      config-map
-                      {:smart-contracts {:format :truffle-json}
-                       :web3-account-balances {:for-contracts [:ETH :DANK]}
-                       :web3-tx-log {:open-on-tx-hash? true}
-                       :reagent-render {:id "app"
-                                        :component-var #'router}
-                       :router {:routes routes
-                                :default-route :route/home
-                                :scroll-top? true}
-                       :notification {:default-show-duration 3000
-                                      :default-hide-duration 1000}})]
+                     config-map
+                     {:smart-contracts {:format :truffle-json}
+                      :web3-account-balances {:for-contracts [:ETH :DANK]}
+                      :web3-tx-log {:open-on-tx-hash? true}
+                      :reagent-render {:id "app"
+                                       :component-var #'router}
+                      :router {:routes routes
+                               :default-route :route/home
+                               :scroll-top? true}
+                      :notification {:default-show-duration 3000
+                                     :default-hide-duration 1000}})]
     (js/console.log "Entire config:" (clj->js full-config))
     (-> (mount/with-args full-config)
         (mount/start)))

--- a/src/memefactory/ui/my_settings/events.cljs
+++ b/src/memefactory/ui/my_settings/events.cljs
@@ -1,0 +1,39 @@
+(ns memefactory.ui.my-settings.events
+  (:require
+   [ajax.core :as ajax]
+   [cljs-web3.core :as web3]
+   [day8.re-frame.http-fx]
+   [district.ui.logging.events :as logging]
+   [district.ui.smart-contracts.queries :as contract-queries]
+   [district.ui.web3-accounts.queries :as account-queries]
+   [district.ui.web3-tx.events :as tx-events]
+   [district0x.re-frame.web3-fx]
+   [print.foo :refer [look] :include-macros true]
+   [re-frame.core :as re-frame]
+   [taoensso.timbre :as log]))
+
+(re-frame/reg-event-fx
+ ::load-email-settings
+ (fn [{:keys [db]} [_ {:keys [address] :as data}]]
+   {:web3/call {:web3 (:web3 db)
+                :fns [{:instance (contract-queries/instance db :district0x-emails)
+                       :fn :get-email
+                       :args [address]
+                       :on-success [::found-encrypted-email data]
+                       :on-error [::error-loading-encrypted-email data]}]}}))
+
+(re-frame/reg-event-fx
+ ::found-encrypted-email
+ (fn [{:keys [db]} [_ {:keys [address] :as data} encrypted-email]]
+   {:db
+    (assoc-in db [:settings address :encrypted-email] encrypted-email)}))
+
+(re-frame/reg-event-fx
+ ::error-loading-encrypted-email
+ (fn [{:keys [db]} [_ :data]]
+   {:db db
+    :dispatch-n [[:district.ui.notification.events/show
+                  "Error loading your encrypted email"]
+                 [::logging/error "Error loading user encrypted email"
+                  data
+                  ::error-loading-encrypted-email]]}))

--- a/src/memefactory/ui/my_settings/page.cljs
+++ b/src/memefactory/ui/my_settings/page.cljs
@@ -7,6 +7,7 @@
     [goog.format.EmailAddress :as email-address]
     [memefactory.ui.components.app-layout :refer [app-layout]]
     [memefactory.ui.contract.district0x-emails :as ms-events]
+    [memefactory.ui.my-settings.events :as my-settings-events]
     [re-frame.core :as re-frame]
     [reagent.core :as r]
     [reagent.ratom :refer [reaction]]
@@ -23,13 +24,13 @@
 
 (defn my-settings []
   (let [public-key-sub (re-frame/subscribe [::gql/query {:queries [[:config [[:ui [:public-key]]]]]}])
-        active-account (re-frame/subscribe [::accounts-subs/active-account])
         form-data (r/atom {})
         errors (reaction {:local (cond-> {}
                                    (not (valid-email? (or (:email @form-data) "")))
                                    (assoc-in [:email :error] "Invalid email format"))})]
     (fn []
       (let [public-key (-> @public-key-sub :config :ui :public-key)
+            active-account (re-frame/subscribe [::accounts-subs/active-account])
             settings (re-frame/subscribe [:memefactory.ui.subs/settings @active-account])]
         [:div.my-settings-box
          [:div.icon]
@@ -45,8 +46,8 @@
             {:form-data form-data
              :id :email
              :for :email}]
-           (when (not-empty (:email @settings))
-             [:div.alert "You already associated " (:email @settings) " with your Ethereum address"])
+           (when (not-empty (:encrypted-email @settings))
+             [:div.alert "You already associated an email with your Ethereum address"])
            [:p "The email associated with your address will be encrypted and stored on a public blockchain. Only our email server will be able to decrypt it. We'll use it to send you automatic notifications about your activity, as well as important website updates. You can unsubscribe at any time by saving a blank email address above. You can view our privacy policy " [nav-anchor {:route :route.privacy-policy/index} "here."]]
            [:p "We use the service " [:a {:href "https://sendgrid.com"} "Sendgrid"] " to generate these emails. You can also always unsubscribe from this service by opting out through their provided links at the bottom of every email. You can view their privacy policy " [:a {:href "https://sendgrid.com/policies/privacy/" } "here."]]]]
          [:div.footer


### PR DESCRIPTION
Fix for #451, checks for the presence of an encrypted email in our mail contract and warns the user if they have an existing email address associated with a particular account. By moving the `subscribe` call for the active account to within the function body of the form-2 component it reacts well to changing accounts in Metamask.

Tested associating an email with an account, switching accounts, then associating an email with a different account.