### PR TITLE
fixes #525

### DIFF
--- a/src/memefactory/ui/components/app_layout.cljs
+++ b/src/memefactory/ui/components/app_layout.cljs
@@ -178,10 +178,13 @@
         active-account (subscribe [:district.ui.web3-accounts.subs/active-account])
         mobile-device? (subscribe [::mobile-subs/coinbase-compatible?])
         coinbase-appstore-link (subscribe [::mf-subs/mobile-coinbase-appstore-link])]
-    (fn [{:keys [:search-atom :meta]}
+    (fn [{:keys [:search-atom :meta :tags]}
          & children]
       [:div.app-container {:id "app-container"}
-       [meta-tags/meta-tags meta {:id "image" :name "og:image" :content (str (-> @root-url :config :ui :root-url) "/assets/images/1_OInGI_RrVwH6uF3OcqJuwQ.jpg")}]
+       [apply meta-tags/meta-tags meta (or tags
+                                           [{:id "image"
+                                             :name "og:image"
+                                             :content (str (-> @root-url :config :ui :root-url) "/assets/images/1_OInGI_RrVwH6uF3OcqJuwQ.jpg")}])]
        [:div.app-menu
         {:class (when-not @drawer-open? "closed")}
         [:div.menu-content

--- a/src/memefactory/ui/meme_detail/page.cljs
+++ b/src/memefactory/ui/meme_detail/page.cljs
@@ -14,6 +14,7 @@
     [district.ui.component.page :refer [page]]
     [district.ui.component.tx-button :as tx-button]
     [district.ui.graphql.subs :as gql]
+    [district.ui.ipfs.subs :as ipfs-subs]
     [district.ui.now.subs :as now-subs]
     [district.ui.router.subs :as router-subs]
     [district.ui.web3-account-balances.subs :as account-balances-subs]
@@ -547,10 +548,14 @@
         ;; :graphql/loading?. Unfortunately this subscription sometimes returns
         ;; nil when it's really still just loading.
         meme-not-loaded? (or (not status)
-                             (and meme-sub (:graphql/loading? @meme-sub)))]
+                             (and meme-sub (:graphql/loading? @meme-sub)))
+        url (:gateway @(subscribe [::ipfs-subs/ipfs]))]
     [app-layout
      {:meta {:title (str "MemeFactory - " title)
-             :description (str "Details of meme " title ". " "MemeFactory is decentralized registry and marketplace for the creation, exchange, and collection of provably rare digital assets.")}}
+             :description (str "Details of meme " title ". " "MemeFactory is decentralized registry and marketplace for the creation, exchange, and collection of provably rare digital assets.")}
+      :tags [{:id "image"
+              :name "og:image"
+              :content (str (format/ensure-trailing-slash url) image-hash)}]}
      [:div.meme-detail-page
       [:section.meme-detail
        [:div.meme-info {:class (when meme-not-loaded? "loading")}


### PR DESCRIPTION
### Summary

Closes #525 .

### Review notes

Changes to meme-detail page and to app-layout to pass image as a custom tag.

### Testing notes

Tested with a meta inspector, after it's on QA we can see if bots render the image.