### PR TITLE
increase the preload to avoid flicker

### DIFF
--- a/src/memefactory/ui/components/infinite_scroll.cljs
+++ b/src/memefactory/ui/components/infinite_scroll.cljs
@@ -20,9 +20,8 @@
      :to-bottom (- page-height (+ window-height scroll-position))}))
 
 
-(defn preload-batch-size [factor]
+(defn container-height-scale-factor [factor]
   (js-invoke js/Infinite "containerHeightScaleFactor" factor))
-
 
 (defn infinite-scroll [props & [children]]
   (let [tutorial-next-fired? (atom false)]
@@ -72,7 +71,7 @@
                                                                                            pos))
                                        (-> js/window (.scrollBy 0 (- 0 element-height))))))
                   :time-scroll-state-lasts-for-after-user-scrolls 100
-                  :preload-batch-size (preload-batch-size 2)
+                  :preload-batch-size (container-height-scale-factor 6)
                   :on-infinite-load (fn []
                                       (when (and has-more?
                                                  (not loading?))

--- a/src/memefactory/ui/components/tiles.cljs
+++ b/src/memefactory/ui/components/tiles.cljs
@@ -22,10 +22,9 @@
 
 
 (defn meme-image [& _]
-  (let [ipfs (subscribe [::ipfs-subs/ipfs])]
+  (let [url (:gateway @(subscribe [::ipfs-subs/ipfs]))]
     (fn [image-hash & [{:keys [rejected?] :as props}]]
-      (let [props (dissoc props :rejected?)
-            url (:gateway @ipfs)]
+      (let [props (dissoc props :rejected?)]
         [:div.meme-card
          props
          (if (and url (not-empty image-hash))


### PR DESCRIPTION
### Summary
My proposed fix for #469. 

### Review notes
The flicker effect is caused by the fact that react-infinite component removes elements dynamically from the DOM, by default only 

This is controlled by the [preload-batch-size](https://github.com/seatgeek/react-infinite#number--object-preloadbatchsize) prop. I increased the preload to be of factor 6, so effectively only after scrolling for 6 x window size the elements get remounted. 

### Testing notes
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/468572/60953577-b8101c80-a2fd-11e9-9fa8-7f53cccb65f0.gif)
