### PR TITLE
closes #528

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -54,7 +54,7 @@
                  [district0x/district-ui-reagent-render "1.0.1"]
                  [district0x/district-ui-router "1.0.5"]
                  [district0x/district-ui-router-google-analytics "1.0.1"]
-                 [district0x/district-ui-smart-contracts "1.0.6"]
+                 [district0x/district-ui-smart-contracts "1.0.8"]
                  [district0x/district-ui-web3 "1.3.2"]
                  [district0x/district-ui-web3-account-balances "1.0.2"]
                  [district0x/district-ui-web3-accounts "1.0.6"]

--- a/src/memefactory/ui/core.cljs
+++ b/src/memefactory/ui/core.cljs
@@ -86,7 +86,8 @@
   (dev-setup)
   (let [full-config (cljs-utils/merge-in
                      config-map
-                     {:smart-contracts {:format :truffle-json}
+                     {:smart-contracts {:format :truffle-json
+                                        :contracts-path "/contracts/build/"}
                       :web3-account-balances {:for-contracts [:ETH :DANK]}
                       :web3-tx-log {:open-on-tx-hash? true}
                       :reagent-render {:id "app"


### PR DESCRIPTION
### Summary

This is a fix for #528. 

### Review notes
Bug is actually caused by the weird convention to use relative paths everywhere (first I saw it in index.html) and now in libraries  (**"./contracts/build/"**) but resurfaced after using the prerendering image to serve UI.

### Testing notes
Contract artifacts were only loaded if navigating to the root route (**"/" => https://memefactory.qa.district0x.io/**), because then relative paths worked with static content, artifacts were empty if navigating directly to a nested path:
(**"dankregistry/submit" => https://memefactory.qa.district0x.io/dankregistry/submit**)
