### PR TITLE
Fix #529 (End prices are displayed inaccurately, or are never reached…

### DIFF
--- a/src/memefactory/ui/components/tiles.cljs
+++ b/src/memefactory/ui/components/tiles.cljs
@@ -93,12 +93,10 @@
 
 
 (defn- calculate-meme-auction-price [meme-auction now]
-  (let [price (shared-utils/calculate-meme-auction-price
-                (-> meme-auction
-                  (update :meme-auction/started-on #(quot (.getTime (gql-utils/gql-date->date %)) 1000)))
-                (quot (.getTime now) 1000))]
-    ;; Add little bit extra reserve, so the transaction doesn't revert
-    (+ price (* 0.0001 price))))
+  (shared-utils/calculate-meme-auction-price
+   (-> meme-auction
+       (update :meme-auction/started-on #(quot (.getTime (gql-utils/gql-date->date %)) 1000)))
+   (quot (.getTime now) 1000)))
 
 
 (defn auction-back-tile [opts meme-auction]
@@ -171,7 +169,8 @@
                                                  (dispatch [::meme-auction/buy {:send-tx/id tx-id
                                                                                 :meme-auction/address (:meme-auction/address meme-auction)
                                                                                 :meme/title title
-                                                                                :value price}]))}
+                                                                                ;; Add little bit extra reserve, so the transaction doesn't revert
+                                                                                :value (+ price (* 0.0001 price))}]))}
               (if @buy-tx-success? "Bought" "Buy")])]]]))))
 
 


### PR DESCRIPTION
Fix for #529 

### Summary

We need to add a small percentage to auction price so the transactions doesn't revert.
This change adds the percentage to the buy transaction instead of general price calculation which is used for UI price displaying and ends up displaying higher prices than it should.
