### PR TITLE
Fix #521 (bug/Rejected memes show up as accepted in registry)

### DIFF
--- a/src/memefactory/server/db.cljs
+++ b/src/memefactory/server/db.cljs
@@ -273,9 +273,10 @@
 (def update-registry-entry! (create-update-fn :reg-entries registry-entry-column-names :reg-entry/address))
 (def get-registry-entry (create-get-fn :reg-entries :reg-entry/address))
 
-(defn all-reg-entries []
-  (db/all {:select [:re.*]
-           :from [[:reg-entries :re]]}))
+(defn all-meme-reg-entries []
+  (db/all {:select [:re.* :m.*]
+           :from [[:reg-entries :re]]
+           :join [[:memes :m] [:= :re.reg-entry/address :m.reg-entry/address]]}))
 
 ;; MEMES
 


### PR DESCRIPTION
### Summary

We should only assign numbers to whitelisted memes that doesn't have numbers. Also we should do it on memes reg entries since we are going to have param change reg entries.