### PR TITLE
Fix #527 (Curators scoreboard challenge counter does not match actual…

### DIFF
--- a/src/memefactory/shared/utils.cljs
+++ b/src/memefactory/shared/utils.cljs
@@ -37,3 +37,11 @@
 (defn debounce [f interval]
   (let [dbnc (Debouncer. f interval)]
     (fn [& args] (.apply (.-fire dbnc) dbnc (to-array args)))))
+
+;; This should follow RegistryEntryLib.sol winningVoteOption
+(defn winning-vote-option [{:keys [:votes/against :votes/for :challenge/reveal-period-end]} quorum now]
+  (if (< now reveal-period-end)
+    :vote.option/no-vote
+    (if (> (* 100 for) (* quorum (+ for against)))
+      :vote.option/vote-for
+      :vote.option/vote-against)))


### PR DESCRIPTION
(Curators scoreboard challenge counter does not match actual history [BUG])

### Summary

Challenge success was inverted. If vote for win, it means the challenger lost.
Found a bunch of issues related to this like not taking into account vote quorum, will file issues about  them.