### PR TITLE
Fix/broken ipfs links

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -46,7 +46,7 @@
                  [district0x/district-ui-component-notification "1.0.0"]
                  [district0x/district-ui-component-tx-button "1.0.0"]
                  [district0x/district-ui-graphql "1.0.9"]
-                 [district0x/district-ui-ipfs "1.0.0" :exclusions [district0x/cljs-ipfs-native]] ;; before deps are updated
+                 [district0x/district-ui-ipfs "1.0.1"]
                  [district0x/district-ui-logging "1.1.0"]
                  [district0x/district-ui-mobile "1.0.0"]
                  [district0x/district-ui-notification "1.0.1"]

--- a/src/memefactory/ui/components/tiles.cljs
+++ b/src/memefactory/ui/components/tiles.cljs
@@ -27,6 +27,10 @@
         [:div.meme-card
          props
          (cond
+
+           (string/includes? src-url "forbidden")
+           [:div.meme-placeholder.initial-fade-in [:img {:src "/assets/icons/mememouth.png"}]]
+
            (string/includes? src-url ".mp4")
            [:video.meme-image.initial-fade-in-delay {:controls false
                                                      :loop true
@@ -38,10 +42,7 @@
                       :type "video/mp4"}]
             [:span "Your browser does not support video tags"]]
 
-           (not-empty src-url)
-           [:img.meme-image.initial-fade-in-delay {:src src-url}]
-
-           :else [:div.meme-placeholder.initial-fade-in [:img {:src "/assets/icons/mememouth.png"}]])
+           :else [:img.meme-image.initial-fade-in-delay {:src src-url}])
          (when rejected?
            [:div.image-tape-container.initial-fade-in-delay
             [:div.image-tape


### PR DESCRIPTION
### Summary

Closes #581 Outdated dependency was puling a wrong version of the library and shadowed the `:opts` changes. 

### Review notes
Most of the changes are in the ipfs component.

### Testing notes
Already commited ropsten memes will have wrong ipfs image hashes. Best course of action is to  ban them with the blacklist.edn mechanism we have built into memefactory.