### PR TITLE
Fix #607 Two proposals for the same parameter change applied in same …

### DIFF
--- a/src/memefactory/server/graphql_resolvers.cljs
+++ b/src/memefactory/server/graphql_resolvers.cljs
@@ -340,7 +340,11 @@
          now (utils/now-in-seconds)
          param-changes-query (cond-> {:select [:*]
                                       :from [:param-changes]
-                                      :left-join [[:reg-entries :re] [:= :re.reg-entry/address :param-changes.reg-entry/address]]}
+                                      :left-join [[:reg-entries :re] [:= :re.reg-entry/address :param-changes.reg-entry/address]]
+                                      :join [:params [:and
+                                                        [:= :param-changes.param-change/db :params.param/db]
+                                                        [:= :param-changes.param-change/key :params.param/key]]]
+                                      :where [:= :param-changes.param-change/original-value :params.param/value]}
 
                                key (sqlh/merge-where [:= key :param-changes.param-change/key])
 

--- a/src/memefactory/ui/config.cljs
+++ b/src/memefactory/ui/config.cljs
@@ -20,8 +20,7 @@
    :logging {:level :debug
              :console? true}
    :time-source :js-date
-   :smart-contracts {:contracts (apply dissoc smart-contracts-dev/smart-contracts skipped-contracts)
-                     :load-method :use-loaded}
+   :smart-contracts {:contracts (apply dissoc smart-contracts-dev/smart-contracts skipped-contracts)}
    :web3-balances {:contracts (select-keys smart-contracts-dev/smart-contracts [:DANK])}
    :web3 {:url "http://localhost:8549"}
    :web3-tx {:disable-loading-recommended-gas-prices? true}
@@ -156,11 +155,12 @@
 (re-frame/reg-sub
  ::all-params
  (fn [db _]
-   (concat
-    (->> (::memefactory-db-params db)
-         (map (fn [[k pm]] (assoc pm :key (keyword "meme" k)))))
-    (->> (::param-change-db-params db)
-         (map (fn [[k pm]] (assoc pm :key (keyword "param-change" k))))))))
+   (when (and (::memefactory-db-params db) (::param-change-db-params db))
+     (concat
+      (->> (::memefactory-db-params db)
+           (map (fn [[k pm]] (assoc pm :key (keyword "meme" k)))))
+      (->> (::param-change-db-params db)
+           (map (fn [[k pm]] (assoc pm :key (keyword "param-change" k)))))))))
 
 (re-frame/reg-sub
  ::param-db-keys-by-db

--- a/src/memefactory/ui/param_change/page.cljs
+++ b/src/memefactory/ui/param_change/page.cljs
@@ -121,26 +121,26 @@
           [:th [:div.collapse-icon {:on-click #(swap! open? not)
                                     :class (when @open? "flipped")}]]]]
         [:tbody
-
          (let [param-val (into {} (map (fn [p] [(:key p) p]) @all-params))]
-           (for [key param-display-order]
-             (let [{:keys [key value set-on]} (param-val key)]
-               ^{:key (str key)}
-               [:tr
-                [:td
-                 [:div
-                  [:div.param-title (:title (param-info key))]
-                  [:div.param-b (:description (param-info key))]]]
-                [:td
-                 [:div
-                  [:div.param-h "Current Value"]
-                  [:div.param-b (str (scale-param-change-value key value) " " (:unit (param-info key)))]]]
-                [:td
-                 [:div
-                  [:div.param-h "Last Change"]
-                  [:div.param-b (time-format/unparse (time-format/formatter "dd/MM/yyyy")
-                                                     (t/local-date-time (gql-utils/gql-date->date set-on)))]]]
-                [:td]])))]]])))
+           (when @all-params
+             (for [key param-display-order]
+               (let [{:keys [key value set-on db] :as pv} (param-val key)]
+                 ^{:key (str key)}
+                 [:tr
+                  [:td
+                   [:div
+                    [:div.param-title (:title (param-info key))]
+                    [:div.param-b (:description (param-info key))]]]
+                  [:td
+                   [:div
+                    [:div.param-h "Current Value"]
+                    [:div.param-b (str (scale-param-change-value key value) " " (:unit (param-info key)))]]]
+                  [:td
+                   [:div
+                    [:div.param-h "Last Change"]
+                    [:div.param-b (time-format/unparse (time-format/formatter "dd/MM/yyyy")
+                                                       (t/local-date-time (gql-utils/gql-date->date set-on)))]]]
+                  [:td]]))))]]])))
 
 
 (defn change-submit-form []

--- a/test/memefactory/tests/graphql_resolvers/graphql_resolvers_tests.cljs
+++ b/test/memefactory/tests/graphql_resolvers/graphql_resolvers_tests.cljs
@@ -112,10 +112,10 @@
         initial-params (let [k ["deposit" "challengePeriodDuration" "commitPeriodDuration" "revealPeriodDuration"]
                              v [1000 1e5 1e4 1e4]]
                          (for [i (range (count k))]
-                           {:initial-param/key (get k i)
-                            :initial-param/db "MEMEREGISTRYADDR"
-                            :initial-param/value (get v i)
-                            :initial-param/set-on now}))
+                           {:param/key (get k i)
+                            :param/db "MEMEREGISTRYADDR"
+                            :param/value (get v i)
+                            :param/set-on now}))
         param-changes (let [v [2000 1e6 1e5 1e5 3000]]
                         (for [i (range (count v))]
                           {:reg-entry/address (str "PCHANGEADDR" i)
@@ -129,13 +129,16 @@
                            :param-change/meta-hash (str "MHASH" i)
                            :param-change/reason (str "Reason " i)
                            :param-change/original-value (case i
-                                                         0 (:initial-param/value (nth initial-params 0))
-                                                         1 (:initial-param/value (nth initial-params 1))
-                                                         2 (:initial-param/value (nth initial-params 2))
-                                                         3 (:initial-param/value (nth initial-params 3))
-                                                         4 (:initial-param/value (nth initial-params 0)))
+                                                         0 (:param/value (nth initial-params 0))
+                                                         1 (:param/value (nth initial-params 1))
+                                                         2 (:param/value (nth initial-params 2))
+                                                         3 (:param/value (nth initial-params 3))
+                                                         4 (:param/value (nth initial-params 0)))
                            :param-change/value (get v i)
                            :param-change/applied-on (+ now (hours->seconds i))}))]
+
+    ;; Create params
+    (meme-db/upsert-params! initial-params)
 
     ;; Generate some users
     (doseq [u all-users]


### PR DESCRIPTION
search-param-changes should only return param changes which original-value is still the current param value. If not we assume that a change already happened and it shouldn't be take into account.