### PR TITLE
closes #596

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -28,7 +28,7 @@
                  [district0x/district-format "1.0.6"]
                  [district0x/district-graphql-utils "1.0.8"]
                  [district0x/district-parsers "1.0.0"]
-                 [district0x/district-sendgrid "1.0.0"]
+                 [district0x/district-sendgrid "1.0.1"]
                  [district0x/district-server-config "1.0.1"]
                  [district0x/district-server-db "1.0.4"]
                  [district0x/district-server-graphql "1.0.16"]

--- a/src/memefactory/server/emailer.cljs
+++ b/src/memefactory/server/emailer.cljs
@@ -2,6 +2,7 @@
   (:require
     [cljs-time.coerce :as time-coerce]
     [cljs-time.core :as t]
+    [clojure.string :as string]
     [district.encryption :as encryption]
     [district.format :as format]
     [district.sendgrid :refer [send-email]]
@@ -18,17 +19,25 @@
     [mount.core :as mount :refer [defstate]]
     [taoensso.timbre :as log]))
 
-
 (defn validate-email [base64-encrypted-email]
   (when-not (empty? base64-encrypted-email)
     (let [email (encryption/decode-decrypt (get-in @config/config [:emailer :private-key]) base64-encrypted-email)]
       (when (email-address/isValidAddress email)
         email))))
 
+(defn email-supported-extension? [image-url]
+  (cond
+    (string/includes? image-url ".png") true
+    (string/includes? image-url ".jpeg") true
+    (string/includes? image-url ".jpg") true
+    (string/includes? image-url ".gif") true
+    :else false))
+
 (defn send-challenge-created-email-handler
   [{:keys [from to
            title
-           meme-url meme-image-url
+           meme-url
+           meme-image-url
            button-url
            time-remaining
            on-success on-error
@@ -45,7 +54,8 @@
     :substitutions {:header (str title " was challenged")
                     :button-title "Vote Now"
                     :button-href button-url
-                    :meme-image-url meme-image-url}
+                    :meme-image-url meme-image-url
+                    :meme-image-class (if (email-supported-extension? meme-image-url) "show" "no-show")}
     :on-success on-success
     :on-error on-error
     :template-id template-id
@@ -90,7 +100,8 @@
 
 (defn send-auction-bought-email-handler
   [{:keys [from to title
-           meme-url meme-image-url
+           meme-url
+           meme-image-url
            button-url
            buyer-address
            buyer-url
@@ -110,7 +121,8 @@
                :substitutions {:header (str title " was sold!")
                                :button-title "My Memefolio"
                                :button-href button-url
-                               :meme-image-url meme-image-url}
+                               :meme-image-url meme-image-url
+                               :meme-image-class (if (email-supported-extension? meme-image-url) "show" "no-show")}
                :on-success on-success
                :on-error on-error
                :template-id template-id
@@ -176,7 +188,8 @@
                :substitutions {:header "Vote Reward"
                                :button-title "My Memefolio"
                                :button-href button-url
-                               :meme-image-url meme-image-url}
+                               :meme-image-url meme-image-url
+                               :meme-image-class (if (email-supported-extension? meme-image-url) "show" "no-show")}
                :on-success on-success
                :on-error on-error
                :template-id template-id
@@ -239,7 +252,8 @@
                :substitutions {:header "Challenge Reward"
                                :button-title "My Memefolio"
                                :button-href button-url
-                               :meme-image-url meme-image-url}
+                               :meme-image-url meme-image-url
+                               :meme-image-class (if (email-supported-extension? meme-image-url) "show" "no-show")}
                :on-success on-success
                :on-error on-error
                :template-id template-id


### PR DESCRIPTION
### Summary

Fix for #596. 

### Review notes
Some email clients, most notably GMAIL have no support for svg and will explicitely block it. As a solution we will use a class to toggle their display in the emails.

