### PR TITLE
Normalize tags to lower-case when syncing meme events

### DIFF
--- a/src/memefactory/server/db.cljs
+++ b/src/memefactory/server/db.cljs
@@ -71,11 +71,11 @@
    [(sql/call :primary-key :meme-token/token-id)]])
 
 (def tags-columns
-  [[:tag/name :varchar primary-key not-nil]])
+  [[:tag/name :varchar primary-key not-nil (sql/raw "COLLATE NOCASE")]])
 
 (def meme-tags-columns
   [[:reg-entry/address address not-nil]
-   [:tag/name :varchar not-nil]
+   [:tag/name :varchar not-nil (sql/raw "COLLATE NOCASE")]
    [(sql/call :primary-key :reg-entry/address :tag/name)]
    [(sql/call :foreign-key :reg-entry/address) (sql/call :references :reg-entries :reg-entry/address) (sql/raw "ON DELETE CASCADE")]
    [(sql/call :foreign-key :tag/name) (sql/call :references :tags :tag/name) (sql/raw "ON DELETE CASCADE")]])

--- a/src/memefactory/styles/component/buttons.clj
+++ b/src/memefactory/styles/component/buttons.clj
@@ -82,7 +82,6 @@
 (defn tag []
   [:&
    {:line-height 1
-    :text-transform :capitalize
     :background-color (c/color :tags-grey)
     :color (c/color :menu-text)
     :margin (em 0.3)


### PR DESCRIPTION
Tags should be normalized. This PR normalizes them at syncer level, where I think is the place to do it.