### PR TITLE
changes to keep the ws connection alive with a ping

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -91,7 +91,6 @@
                express-graphql
                cljsjs/react-with-addons]
 
-
   :plugins [[lein-auto "0.1.2"]
             [lein-cljsbuild "1.1.7"]
             [lein-figwheel "0.5.18"]

--- a/project.clj
+++ b/project.clj
@@ -32,9 +32,9 @@
                  [district0x/district-server-graphql "1.0.18"]
                  [district0x/district-server-logging "1.0.5"]
                  [district0x/district-server-middleware-logging "1.0.0"]
-                 [district0x/district-server-smart-contracts "1.2.0"]
-                 [district0x/district-server-web3 "1.2.0"]
-                 [district0x/district-server-web3-events "1.1.6"]
+                 [district0x/district-server-smart-contracts "1.2.1"]
+                 [district0x/district-server-web3 "1.2.1"]
+                 [district0x/district-server-web3-events "1.1.7"]
                  [district0x/district-time "1.0.1"]
                  [district0x/district-ui-component-active-account "1.0.1"]
                  [district0x/district-ui-component-active-account-balance "1.0.1"]
@@ -90,6 +90,7 @@
   :exclusions [funcool/bide
                express-graphql
                cljsjs/react-with-addons]
+
 
   :plugins [[lein-auto "0.1.2"]
             [lein-cljsbuild "1.1.7"]

--- a/src/memefactory/server/contract/param_change.cljs
+++ b/src/memefactory/server/contract/param_change.cljs
@@ -3,7 +3,7 @@
             [district.server.smart-contracts :as smart-contracts]))
 
 (defn load-param-change [contract-addr]
-  (promise-> (smart-contracts/contract-call (instance :param-change contract-addr) :load-param-change)
+  (promise-> (smart-contracts/contract-call (smart-contracts/instance :param-change contract-addr) :load-param-change)
              (fn [param-change]
                {:reg-entry/address contract-addr
                 :db (aget param-change "0")

--- a/src/memefactory/server/db.cljs
+++ b/src/memefactory/server/db.cljs
@@ -109,7 +109,7 @@
    [:param-change/original-value :unsigned :integer not-nil]
    [:param-change/applied-on :unsigned :integer default-nil]
    [:param-change/meta-hash ipfs-hash not-nil]
-   [:param-change/reason :varchar not-nil]
+   [:param-change/reason :varchar default-nil]
    [(sql/call :primary-key :reg-entry/address)]
    [(sql/call :foreign-key :reg-entry/address) (sql/call :references :reg-entries :reg-entry/address) (sql/raw "ON DELETE CASCADE")]])
 

--- a/src/memefactory/server/dev.cljs
+++ b/src/memefactory/server/dev.cljs
@@ -177,14 +177,14 @@
                                                  (mount/stop #'memefactory.server.db/memefactory-db
                                                              #'district.server.web3-events/web3-events
                                                              #'memefactory.server.syncer/syncer
-                                                             ;; #'memefactory.server.emailer/emailer
+                                                             #'memefactory.server.emailer/emailer
                                                              ))
                                    :on-online (fn []
                                                 (log/warn "Ethereum node went online again, starting syncing modules" {:resyncs (swap! resync-count inc)} ::web3-watcher)
                                                 (mount/start #'memefactory.server.db/memefactory-db
                                                              #'district.server.web3-events/web3-events
                                                              #'memefactory.server.syncer/syncer
-                                                             ;; #'memefactory.server.emailer/emailer
+                                                             #'memefactory.server.emailer/emailer
                                                              ))}
                             :ipfs {:host "http://127.0.0.1:5001"
                                    :endpoint "/api/v0"

--- a/src/memefactory/server/dev.cljs
+++ b/src/memefactory/server/dev.cljs
@@ -230,10 +230,6 @@
   (.on js/process "unhandledRejection"
        (fn [reason p] (log/error "Unhandled promise rejection" {:reason reason})))
 
-  ;; TODO : remove
-  (.on js/process "uncaughtException"
-       (fn [error] (log/error "Unhandled exception" {:error error})))
-
   (when-not (= (last args) "--nostart")
     (log/debug "Mounting... (Pass the argument --nostart to prevent mounting on start)")
     (start)))

--- a/src/memefactory/server/dev.cljs
+++ b/src/memefactory/server/dev.cljs
@@ -1,50 +1,48 @@
 (ns memefactory.server.dev
-  (:require
-   [ajax.core :as http]
-   [bignumber.core :as bn]
-   [camel-snake-kebab.core :as cs :include-macros true]
-   [cljs-promises.async]
-   [cljs-time.core :as t]
-   [cljs.nodejs :as nodejs]
-   [cljs.pprint :as pprint]
-   [clojure.pprint :refer [print-table]]
-   [clojure.string :as string]
-   [district.graphql-utils :as graphql-utils]
-   [district.server.config :refer [config]]
-   [district.server.db :as db]
-   [district.server.graphql :as graphql]
-   [district.server.graphql.utils :as utils]
-   [district.server.logging :refer [logging]]
-   [district.server.middleware.logging :refer [logging-middlewares]]
-   [district.server.smart-contracts]
-   [district.server.web3-events]
-   [district.server.web3]
-   [district.shared.async-helpers :as async-helpers]
-   [goog.date.Date]
-   [graphql-query.core :refer [graphql-query]]
-   [memefactory.server.constants :as constants]
-   [memefactory.server.contract.dank-token :as dank-token]
-   [memefactory.server.contract.eternal-db :as eternal-db]
-   [memefactory.server.contract.registry-entry :as registry-entry]
-   [memefactory.server.conversion-rates]
-   [memefactory.server.dank-faucet-monitor]
-   [memefactory.server.db :as memefactory-db]
-   [memefactory.server.emailer]
-   [memefactory.server.generator :as generator]
-   [memefactory.server.graphql-resolvers :refer [resolvers-map reg-entry-status-sql-clause]]
-   [memefactory.server.ipfs]
-   [memefactory.server.ranks-cache]
-   [memefactory.server.syncer :as syncer]
-   [memefactory.server.twitter-bot]
-   [memefactory.server.utils :as server-utils]
-   [memefactory.shared.graphql-schema :refer [graphql-schema]]
-   [memefactory.shared.smart-contracts-dev :as smart-contracts-dev]
-   [memefactory.shared.smart-contracts-prod :as smart-contracts-prod]
-   [memefactory.shared.smart-contracts-qa :as smart-contracts-qa]
-   [memefactory.shared.utils :as shared-utils]
-   [mount.core :as mount]
-   [taoensso.timbre :as log]
-   ))
+  (:require [ajax.core :as http]
+            [bignumber.core :as bn]
+            [camel-snake-kebab.core :as cs :include-macros true]
+            [cljs-promises.async]
+            [cljs-time.core :as t]
+            [cljs.nodejs :as nodejs]
+            [cljs.pprint :as pprint]
+            [clojure.pprint :refer [print-table]]
+            [clojure.string :as string]
+            [district.graphql-utils :as graphql-utils]
+            [district.server.config :refer [config]]
+            [district.server.db :as db]
+            [district.server.graphql :as graphql]
+            [district.server.graphql.utils :as utils]
+            [district.server.logging :refer [logging]]
+            [district.server.middleware.logging :refer [logging-middlewares]]
+            [district.server.smart-contracts]
+            [district.server.web3-events]
+            [district.server.web3]
+            [district.shared.async-helpers :as async-helpers]
+            [goog.date.Date]
+            [graphql-query.core :refer [graphql-query]]
+            [memefactory.server.constants :as constants]
+            [memefactory.server.contract.dank-token :as dank-token]
+            [memefactory.server.contract.eternal-db :as eternal-db]
+            [memefactory.server.contract.registry-entry :as registry-entry]
+            [memefactory.server.conversion-rates]
+            [memefactory.server.dank-faucet-monitor]
+            [memefactory.server.db :as memefactory-db]
+            [memefactory.server.emailer]
+            [memefactory.server.generator :as generator]
+            [memefactory.server.graphql-resolvers :refer [resolvers-map reg-entry-status-sql-clause]]
+            [memefactory.server.ipfs]
+            [memefactory.server.ranks-cache]
+            [memefactory.server.syncer :as syncer]
+            [memefactory.server.twitter-bot]
+            [memefactory.server.utils :as server-utils]
+            [memefactory.shared.graphql-schema :refer [graphql-schema]]
+            [memefactory.shared.smart-contracts-dev :as smart-contracts-dev]
+            [memefactory.shared.smart-contracts-prod :as smart-contracts-prod]
+            [memefactory.shared.smart-contracts-qa :as smart-contracts-qa]
+            [memefactory.shared.utils :as shared-utils]
+            [mount.core :as mount]
+            [taoensso.timbre :as log]))
 
 (nodejs/enable-util-print!)
 
@@ -54,6 +52,8 @@
 (def graphql-module (nodejs/require "graphql"))
 (def parse-graphql (aget graphql-module "parse"))
 (def visit (aget graphql-module "visit"))
+
+(defonce resync-count (atom 0))
 
 (defn on-jsload []
   (graphql/restart {:schema (utils/build-schema graphql-schema
@@ -173,17 +173,19 @@
                                       :graphiql true}
                             :web3 {:url "ws://127.0.0.1:8545"
                                    :on-offline (fn []
-                                                 (log/error "Ethereum node went offline, stopping syncing modules" ::web3-watcher)
+                                                 (log/warn "Ethereum node went offline, stopping syncing modules" {:resyncs @resync-count} ::web3-watcher)
                                                  (mount/stop #'memefactory.server.db/memefactory-db
-                                                  #'district.server.web3-events/web3-events
-                                                  #'memefactory.server.syncer/syncer
-                                                  #'memefactory.server.emailer/emailer))
+                                                             #'district.server.web3-events/web3-events
+                                                             #'memefactory.server.syncer/syncer
+                                                             ;; #'memefactory.server.emailer/emailer
+                                                             ))
                                    :on-online (fn []
-                                                (log/warn "Ethereum node went online again, starting syncing modules" ::web3-watcher)
+                                                (log/warn "Ethereum node went online again, starting syncing modules" {:resyncs (swap! resync-count inc)} ::web3-watcher)
                                                 (mount/start #'memefactory.server.db/memefactory-db
-                                                 #'district.server.web3-events/web3-events
-                                                 #'memefactory.server.syncer/syncer
-                                                 #'memefactory.server.emailer/emailer))}
+                                                             #'district.server.web3-events/web3-events
+                                                             #'memefactory.server.syncer/syncer
+                                                             ;; #'memefactory.server.emailer/emailer
+                                                             ))}
                             :ipfs {:host "http://127.0.0.1:5001"
                                    :endpoint "/api/v0"
                                    :gateway "http://127.0.0.1:8080/ipfs"}
@@ -226,7 +228,11 @@
   (async-helpers/extend-promises-as-channels!)
 
   (.on js/process "unhandledRejection"
-       (fn [reason p] (log/error "Unhandled promise rejection " {:reason reason})))
+       (fn [reason p] (log/error "Unhandled promise rejection" {:reason reason})))
+
+  ;; TODO : remove
+  (.on js/process "uncaughtException"
+       (fn [error] (log/error "Unhandled exception" {:error error})))
 
   (when-not (= (last args) "--nostart")
     (log/debug "Mounting... (Pass the argument --nostart to prevent mounting on start)")

--- a/src/memefactory/ui/config.cljs
+++ b/src/memefactory/ui/config.cljs
@@ -69,7 +69,7 @@
    :smart-contracts {:contracts (apply dissoc smart-contracts-prod/smart-contracts skipped-contracts)
                      :load-method :use-loaded}
    :web3-balances {:contracts (select-keys smart-contracts-prod/smart-contracts [:DANK])}
-   :web3 {:url "https://mainnet.district0x.io"}
+   :web3 {:url "https://mainnet.infura.io"}
    :web3-tx-log {:disable-using-localstorage? false
                  :open-on-tx-hash? true
                  :tx-costs-currencies [:USD]


### PR DESCRIPTION
### Summary

This PR addresses a couple separate problems:

1. Infura drops idle ws connections after approximately 60 seconds, unfortunately quietly for the client, never triggering `on-disconnect`

2. Infura uses a cache of events, but presumably only for some of the web3 RPC calls. This manifested because when processing events we use `eth_getblockbynumber`  to get the event timestamp. 
This would throw a fatal exception (only when processing latest events), because even though they arrived the block was presumably not yet cached by infura.   

3. https://github.com/district0x/memefactory/issues/664

Ad 1) is addressed by altering the `server-web3-library` and adding a continuous keep-alive poll. Should it ever encounter an exception, the system goes into an offline mode and starts polling for the connection to go back online. For monitoring purposes I started logging the number of resyncs due to websocket connection dropping. We also detect the `on-disconnect` event but as shown before it's not to be trusted 100%.

Ad 2) I added a `wait-for-block` function in `server-smart-contracts` library, which polls until the block is availiable. 

Ad 3) changed the model (reason field can be nil) 