### PR TITLE
Fix #686 (Meme shows incorrect status)

### DIFF
--- a/src/memefactory/ui/meme_detail/page.cljs
+++ b/src/memefactory/ui/meme_detail/page.cljs
@@ -586,7 +586,7 @@
              (if exists?
                [:div.registry {:key :registry}
                 [:h1 title]
-                [:div.status (case (gql-utils/gql-name->kw status)
+                [:div.status (case status
                                :reg-entry.status/whitelisted [:label.in-registry "In Registry"]
                                :reg-entry.status/blacklisted [:label.rejected "Rejected from Registry"]
                                :reg-entry.status/challenge-period [:label.rejected "Open for Challenge"]


### PR DESCRIPTION
The detail status header was broken for every meme. Looks like we broke it when we transitioned from calculate status in the server to calculate it on the client.