### PR TITLE
Add share buttons

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,7 @@
                  [cljsjs/react "16.4.1-0"]
                  [cljsjs/react-dom "16.4.1-0"]
                  [cljsjs/react-infinite "0.13.0-0"]
-                 [cljsjs/react-share "4.4.0-0"]
+                 [io.github.cljsjs/react-share "4.4.0-0"]
                  [com.andrewmcveigh/cljs-time "0.5.2"]
                  [com.taoensso/encore "2.92.0"]
                  [com.taoensso/timbre "4.10.0"]

--- a/project.clj
+++ b/project.clj
@@ -15,6 +15,7 @@
                  [cljsjs/react "16.4.1-0"]
                  [cljsjs/react-dom "16.4.1-0"]
                  [cljsjs/react-infinite "0.13.0-0"]
+                 [cljsjs/react-share "4.4.0-0"]
                  [com.andrewmcveigh/cljs-time "0.5.2"]
                  [com.taoensso/encore "2.92.0"]
                  [com.taoensso/timbre "4.10.0"]

--- a/src/memefactory/styles/component/share_buttons.clj
+++ b/src/memefactory/styles/component/share_buttons.clj
@@ -5,6 +5,9 @@
 
 
 (defstyles core
+  [:.share-buttons
+   [:.react-share__ShareButton+.react-share__ShareButton
+    {:margin-left (em 0.5)}]]
   [:.meme-detail
    [:.share-buttons
     {:position "absolute"

--- a/src/memefactory/styles/component/share_buttons.clj
+++ b/src/memefactory/styles/component/share_buttons.clj
@@ -1,20 +1,20 @@
 (ns memefactory.styles.component.share-buttons
   (:require [garden.def :refer [defstyles]]
-            [garden.units :refer [px,em]]
+            [garden.units :refer [px, em]]
             [memefactory.styles.base.media :refer [for-media-max]]))
 
 
 (defstyles core
-  [:.share-buttons
-   {:position "absolute"
-    :top   (em 2)
-    :right  (em 2)}
+  [:.meme-detail
+   [:.share-buttons
+    {:position "absolute"
+     :top      (em 2)
+     :right    (em 2)}
 
-   (for-media-max :tablet
-                  [:&
-                   {:top "auto" :right "auto" :bottom (em 2), :left (em 2)}])]
-  [:.share-buttons-bottom-container
-   (for-media-max :tablet
-                  [:&
-                   {:display "block" :height (px 32) :margin-top (em 2)}])
-   ])
+    (for-media-max :tablet
+                   [:&
+                    {:top "auto" :right "auto" :bottom (em 2), :left (em 2)}])]
+   [:.share-buttons-bottom-container
+    (for-media-max :tablet
+                   [:&
+                    {:display "block" :height (px 32) :margin-top (em 2)}])]])

--- a/src/memefactory/styles/component/share_buttons.clj
+++ b/src/memefactory/styles/component/share_buttons.clj
@@ -1,0 +1,20 @@
+(ns memefactory.styles.component.share-buttons
+  (:require [garden.def :refer [defstyles]]
+            [garden.units :refer [px,em]]
+            [memefactory.styles.base.media :refer [for-media-max]]))
+
+
+(defstyles core
+  [:.share-buttons
+   {:position "absolute"
+    :top   (em 2)
+    :right  (em 2)}
+
+   (for-media-max :tablet
+                  [:&
+                   {:top "auto" :right "auto" :bottom (em 2), :left (em 2)}])]
+  [:.share-buttons-bottom-container
+   (for-media-max :tablet
+                  [:&
+                   {:display "block" :height (px 32) :margin-top (em 2)}])
+   ])

--- a/src/memefactory/styles/core.clj
+++ b/src/memefactory/styles/core.clj
@@ -11,6 +11,7 @@
             [memefactory.styles.component.main-content :as main-content]
             [memefactory.styles.component.selling-panel :as selling-panel]
             [memefactory.styles.component.spinner :as spinner]
+            [memefactory.styles.component.share-buttons :as share-buttons]
             [memefactory.styles.container.tiles :as tiles]
             [memefactory.styles.pages.about :as page.about]
             [memefactory.styles.pages.dankregistry :as page.dankregistry]
@@ -41,6 +42,7 @@
   page.marketplace/core
   form/core
   spinner/core
+  share-buttons/core
   account-balances/core
   page.memefolio/core
   page.dankregistry/core

--- a/src/memefactory/ui/components/search.cljs
+++ b/src/memefactory/ui/components/search.cljs
@@ -5,7 +5,8 @@
    [print.foo :refer [look] :include-macros true]
    [reagent.core :as r]
    [re-frame.core :as re-frame]
-   [memefactory.ui.events :as mf-events])
+   [memefactory.ui.events :as mf-events]
+   [memefactory.ui.components.share-buttons :as share-buttons])
   (:require-macros [reagent.ratom :refer [reaction]]))
 
 
@@ -44,7 +45,8 @@
       [:div.icon]
       [:div.header
        [:h2 title]
-       [:h3 sub-title]]
+       [:h3 sub-title]
+       [share-buttons/share-buttons (. (. js/document -location) -href)]]
       [:div.body
        [:div.form
         [with-label

--- a/src/memefactory/ui/components/share_buttons.cljs
+++ b/src/memefactory/ui/components/share_buttons.cljs
@@ -1,0 +1,25 @@
+(ns memefactory.ui.components.share-buttons
+  (:require
+    [district.ui.window-size.subs :as w-size-subs]
+    [re-frame.core :refer [subscribe]]
+    [reagent.core :as r]
+    [taoensso.timbre :as log :refer [spy]]
+    [cljsjs.react-share]))
+
+(def twitter-share-button (r/adapt-react-class js/ReactShare.TwitterShareButton))
+(def twitter-icon (r/adapt-react-class js/ReactShare.TwitterIcon))
+(def facebook-share-button (r/adapt-react-class js/ReactShare.FacebookShareButton))
+(def facebook-icon (r/adapt-react-class js/ReactShare.FacebookIcon))
+(def telegram-share-button (r/adapt-react-class js/ReactShare.TelegramShareButton))
+(def telegram-icon (r/adapt-react-class js/ReactShare.TelegramIcon))
+(def reddit-share-button (r/adapt-react-class js/ReactShare.RedditShareButton))
+(def reddit-icon (r/adapt-react-class js/ReactShare.RedditIcon))
+
+(defn share-buttons [url]
+  [:div.share-buttons
+   [twitter-share-button {:url url} [twitter-icon {:size 32 :round true}]]
+   [facebook-share-button {:url url} [facebook-icon {:size 32 :round true}]]
+   [telegram-share-button {:url url} [telegram-icon {:size 32 :round true}]]
+   [reddit-share-button {:url url} [reddit-icon {:size 32 :round true}]]
+   ]
+  )

--- a/src/memefactory/ui/components/share_buttons.cljs
+++ b/src/memefactory/ui/components/share_buttons.cljs
@@ -1,9 +1,6 @@
 (ns memefactory.ui.components.share-buttons
   (:require
-    [district.ui.window-size.subs :as w-size-subs]
-    [re-frame.core :refer [subscribe]]
     [reagent.core :as r]
-    [taoensso.timbre :as log :refer [spy]]
     [cljsjs.react-share]))
 
 (def twitter-share-button (r/adapt-react-class js/ReactShare.TwitterShareButton))

--- a/src/memefactory/ui/meme_detail/page.cljs
+++ b/src/memefactory/ui/meme_detail/page.cljs
@@ -26,6 +26,7 @@
             [memefactory.ui.components.search :as search]
             [memefactory.ui.components.spinner :as spinner]
             [memefactory.ui.components.tiles :as tiles]
+            [memefactory.ui.components.share-buttons :as share-buttons]
             [memefactory.ui.contract.registry-entry :as registry-entry]
             [memefactory.ui.dank-registry.vote-page :as vote-page]
             [memefactory.ui.events :as memefactory-events]
@@ -585,6 +586,7 @@
              [tiles/meme-image image-hash {:rejected? (-> (gql-utils/gql-name->kw status) (= :reg-entry.status/blacklisted))}]
              (if exists?
                [:div.registry {:key :registry}
+                [share-buttons/share-buttons (. (. js/document -location) -href)]
                 [:h1 title]
                 [:div.status (case status
                                :reg-entry.status/whitelisted [:label.in-registry "In Registry"]
@@ -632,7 +634,8 @@
                                 :params nil
                                 :query {:term title}
                                 :class "search memefolio"}
-                    "Search On Memefolio"])]]
+                    "Search On Memefolio"])]
+                [:div.share-buttons-bottom-container]]
                )))])]
       [:section.history
        [:div.history-component


### PR DESCRIPTION
### Summary

to fix https://github.com/district0x/memefactory/issues/701

### Review notes

Instagram doesn't provide sharing feature, so it's not possible to add a instagram button.

### Testing notes
![Screenshot from 2021-06-28 23-38-14](https://user-images.githubusercontent.com/1391892/123664499-f942c380-d869-11eb-8280-157f88c3d5c8.png)
![Screenshot from 2021-06-28 23-31-35](https://user-images.githubusercontent.com/1391892/123664509-fb0c8700-d869-11eb-9de5-0d46bb723473.png)
![Screenshot from 2021-06-28 23-38-24](https://user-images.githubusercontent.com/1391892/123664528-fe077780-d869-11eb-996b-6f2ec93f3691.png)
![Screenshot from 2021-06-28 23-38-00](https://user-images.githubusercontent.com/1391892/123664531-fea00e00-d869-11eb-9cbb-c76156a10cd0.png)

