### PR TITLE
Fix account balances reloading

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -55,7 +55,7 @@
                  [district0x/district-ui-router-google-analytics "1.0.1"]
                  [district0x/district-ui-smart-contracts "1.0.9"]
                  [district0x/district-ui-web3 "1.3.2"]
-                 [district0x/district-ui-web3-account-balances "1.0.2"]
+                 [district0x/district-ui-web3-account-balances "1.0.3"]
                  [district0x/district-ui-web3-accounts "1.0.7"]
                  [district0x/district-ui-web3-balances "1.0.2"]
                  [district0x/district-ui-web3-sync-now "1.0.3-2"]
@@ -68,7 +68,7 @@
                  [district0x/re-frame-ipfs-fx "1.1.1"]
                  [funcool/bide "1.6.1-SNAPSHOT"] ;; version with fix for duplicated query params
                  [garden "1.3.5"]
-                 [io.github.district0x/district-ui-web3-chain "1.0.0"]
+                 [io.github.district0x/district-ui-web3-chain "1.0.1"]
                  [medley "1.0.0"]
                  [mount "0.1.16"]
                  [org.clojars.mmb90/cljs-cache "0.1.4"]

--- a/src/memefactory/ui/components/ens_resolver.cljs
+++ b/src/memefactory/ui/components/ens_resolver.cljs
@@ -84,13 +84,14 @@
   (let [instance (contract-queries/instance db :ens)
     namehash (build-namehash (str (string/lower-case (web3-utils/remove-0x addr)) ".addr.reverse" ))
     data {:addr addr :namehash namehash}]
+    (when (not-empty (contract-queries/contract-abi db :ens))
       {:web3/call
         {:web3 (web3-queries/web3 db)
          :fns [{:instance instance
                 :fn :resolver
                 :args [namehash]
                 :on-success [::resolver-get-address data]
-                :on-error [::logging/error "Error calling ENS Registry" data ::reverse-resolve-address]}]}})))
+                :on-error [::logging/error "Error calling ENS Registry" data ::reverse-resolve-address]}]}}))))
 
 
 ;; Handler for processing the response coming from the ENS registry, which indicates


### PR DESCRIPTION
### Summary

Polygon RPCs seem to have some troubles with the way web3 v0.19 listens for specific contract events.
This causes the DANK balance not to be updated when spending or receiving DANK tokens as part of a transfer.
This PR is a workaround to fix that. It explicitly creates a watcher for checking the DANK account balance.