### PR TITLE
Replace bignumber dependency with native BigInt

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "babel-polyfill": "^6.26.0",
     "babel-register": "^6.26.0",
     "better-sqlite3": "^5.4.3",
-    "bignumber.js": "9.0.1",
     "chalk": "2.4.2",
     "cors": "2.8.5",
     "eccjs": "0.3.1",

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,6 @@
                  [camel-snake-kebab "0.4.0"]
                  [cljs-node-io "1.1.2"]
                  [cljs-web3-next "0.1.4"]
-                 [cljsjs/bignumber "9.0.0-0"]
                  [cljsjs/buffer "5.1.0-1"]
                  [cljsjs/d3 "4.12.0-0"]
                  [cljsjs/filesaverjs "1.3.3-0"]

--- a/src/memefactory/server/syncer.cljs
+++ b/src/memefactory/server/syncer.cljs
@@ -1,7 +1,6 @@
 (ns memefactory.server.syncer
   (:require [bignumber.core :as bn]
             [camel-snake-kebab.core :as camel-snake-kebab]
-            [cljsjs.bignumber :as bignumber]
             [cljs-web3-next.eth :as web3-eth]
             [cljs-web3-next.utils :as web3-utils]
             [cljs.core.async.impl.protocols :refer [ReadPort]]
@@ -259,21 +258,21 @@
 
 (defn meme-minted-event [_ {:keys [:args]}]
   (let [{:keys [:registry-entry :creator :token-start-id :token-end-id :total-minted :timestamp]} args
-        token-start-id (bignumber/BigNumber token-start-id)
-        token-end-id (bignumber/BigNumber token-end-id)
+        token-start-id (js/BigInt token-start-id)
+        token-end-id (js/BigInt token-end-id)
         total-minted (bn/number total-minted)
         token-ids (loop [token-id token-start-id
                          token-ids []]
                     (do
-                      (if (bn/> token-id token-end-id)
+                      (if (> token-id token-end-id)
                        token-ids
-                       (recur (bn/+ token-id 1) (conj token-ids (bn/fixed token-id))))))
+                       (recur (+ token-id (js/BigInt 1)) (conj token-ids (str token-id))))))
         ]
     (db/insert-meme-tokens! {:token-ids token-ids
                              :reg-entry/address registry-entry})
     (db/update-meme! {:reg-entry/address registry-entry
                       :meme/first-mint-on timestamp
-                      :meme/token-id-start (bn/fixed token-start-id)
+                      :meme/token-id-start (str token-start-id)
                       :meme/total-minted total-minted})
     (doseq [tid token-ids]
       (db/upsert-meme-token-owner! {:meme-token/token-id tid


### PR DESCRIPTION
### Summary
cljsjs/bignumber dependency is giving some troubles when compiling using optimizations (e.g., for qa/prod). This PR gets rid of it and rely on js/BigInt for parsing the token-id instead.
