### PR TITLE
fix js call when using compiler optimization

### DIFF
--- a/src/memefactory/ui/contract/bridge.cljs
+++ b/src/memefactory/ui/contract/bridge.cljs
@@ -139,7 +139,7 @@
   ::call-exit-manager
   (fn [{:keys [:web3 :withdraw-tx :network :version version :on-success :on-error :on-complete :method] :as params}]
     (let [options {:network network :version version :parent-provider (aget web3 "currentProvider")}
-          pos (-> js/Matic (.MaticPOSClient (cljkk->js options)))
+          pos (.call (goog.object/get js/Matic "MaticPOSClient") js/Matic (cljkk->js options))
           method (name (cs/->camelCase method))]
       (-> (.. pos -posRootChainManager -exitManager)
           (js-invoke method withdraw-tx event-sig)


### PR DESCRIPTION
### Summary

in advanced compilation mode, the compiler shortens the names of properties and methods, to save space. Use a different way to call js matic method to avoid class renaming in there.
