### PR TITLE
Make migrations resumable

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "karma": "1.7.1",
     "karma-cli": "1.0.1",
     "karma-cljs-test": "0.1.0",
-    "truffle": "4.1.17",
+    "truffle": "5.4.9",
     "truffle-hdwallet-provider": "1.0.12"
   },
   "engines": {


### PR DESCRIPTION
### Summary

The main migration file which deploys all memefactory contracts makes around 40 transactions. If only one of them fails, it will start over again. This PR modifies the migration file to retry from the latest successful transaction.
